### PR TITLE
Update base.py

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     "wagtail.images",
     "wagtail.search",
     "wagtail.admin",
+    "wagtail.contrib.search_promotions",
     "wagtail",
     "modelcluster",
     "taggit",


### PR DESCRIPTION
Fixed the error: 'wagtailsearchpromotions_tags' is not a registered tag library, ensuring the search feature works correctly.

Fixes #32