### PR TITLE
Fix: Add missing imports for pagination exceptions

### DIFF
--- a/project_name/news/models.py
+++ b/project_name/news/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.db.models.functions import Coalesce
-from django.core.paginator import Paginator
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from wagtail.admin.panels import FieldPanel, HelpPanel, InlinePanel, MultiFieldPanel
 from wagtail.fields import RichTextField
 from wagtail.search import index


### PR DESCRIPTION
This fixes a NameError in `NewsListingPage.paginate_queryset()` 
by importing `PageNotAnInteger` and `EmptyPage` from `django.core.paginator`.

Without these imports, pagination exceptions are not properly caught
when an invalid or out-of-range page number is requested.