### PR TITLE
Fix missing imports for paginator exceptions

### DIFF
--- a/project_name/news/models.py
+++ b/project_name/news/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.db.models.functions import Coalesce
-from django.core.paginator import Paginator
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from wagtail.admin.panels import FieldPanel, HelpPanel, InlinePanel, MultiFieldPanel
 from wagtail.fields import RichTextField
 from wagtail.search import index


### PR DESCRIPTION
## Summary
- import `PageNotAnInteger` and `EmptyPage` from `django.core.paginator`
- ensure exceptions referenced in `NewsListingPage.paginate_queryset` are properly defined

## Why
Closes #65: the exceptions were used but not imported, so they were never caught correctly.
