### PR TITLE
Replace hardcoded 'Wagtail Starter Kit' strings with dynamic site name issue#71

### DIFF
--- a/templates/navigation/footer.html
+++ b/templates/navigation/footer.html
@@ -117,7 +117,7 @@
         </div>
     </div>
     <p class="font-codepro text-base text-black dark:text-white opacity-60 pt-10 md:pt-20 mb-10 leading-6">
-        © {% now "Y" %} Wagtail Starter Kit
+        © {% now "Y" %}  {{ current_site.site_name }}
     </p>
 </footer>
 {% endverbatim %}

--- a/templates/navigation/header.html
+++ b/templates/navigation/header.html
@@ -9,7 +9,7 @@
             href="/"
             data-header-logo
             class="header-logo z-30 uppercase font-semibold text-3xl"
-            aria-label="Go to the Wagtail Starter Kit homepage">
+            aria-label="Go to the {{ current_site.site_name }} homepage">
             {{ current_site.site_name|default:"Site name" }}
         </a>
 

--- a/templates/navigation/header.html
+++ b/templates/navigation/header.html
@@ -8,8 +8,7 @@
         <a 
             href="/"
             data-header-logo
-            class="header-logo z-30 uppercase font-semibold text-3xl"
-            aria-label="Go to the {{ current_site.site_name }} homepage">
+            class="header-logo z-30 uppercase font-semibold text-3xl">
             {{ current_site.site_name|default:"Site name" }}
         </a>
 


### PR DESCRIPTION
This replaces hardcoded instances of "Wagtail Starter Kit"
in header.html and footer.html with {{ current_site.site_name }}.

This ensures generated sites display the configured site name
instead of the default template name.