### PR TITLE
Add LinkedIn profile type option for social settings

### DIFF
--- a/fixtures/demo.json
+++ b/fixtures/demo.json
@@ -576,6 +576,7 @@
       ],
       "twitter_handle": "test",
       "linkedin_handle": "test",
+      "linkedin_profile_type": "company",
       "facebook_app_id": "test",
       "instagram_handle": "test",
       "tiktok_handle": "test",

--- a/project_name/utils/migrations/0001_initial.py
+++ b/project_name/utils/migrations/0001_initial.py
@@ -54,6 +54,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('twitter_handle', models.CharField(blank=True, help_text='Your Twitter username without the @, e.g. katyperry', max_length=255)),
                 ('linkedin_handle', models.CharField(blank=True, help_text='Your Linkedin handle, e.g. katyperry.', max_length=255)),
+                ('linkedin_profile_type', models.CharField(choices=[('company', 'Company page'), ('in', 'Personal profile')], default='company', help_text='Choose whether the LinkedIn handle is for a company page or personal profile.', max_length=20)),
                 ('facebook_app_id', models.CharField(blank=True, help_text='Your Facebook app ID.', max_length=255)),
                 ('instagram_handle', models.CharField(blank=True, help_text='Your Instagram username, e.g. katyperry', max_length=255)),
                 ('tiktok_handle', models.CharField(blank=True, help_text='Your TikTok username, e.g. katyperry', max_length=255)),

--- a/project_name/utils/models.py
+++ b/project_name/utils/models.py
@@ -177,6 +177,13 @@ class Statistic(models.Model):
 
 @register_setting
 class SocialMediaSettings(BaseSiteSetting):
+    LINKEDIN_PROFILE_COMPANY = "company"
+    LINKEDIN_PROFILE_PERSONAL = "in"
+    LINKEDIN_PROFILE_CHOICES = [
+        (LINKEDIN_PROFILE_COMPANY, "Company page"),
+        (LINKEDIN_PROFILE_PERSONAL, "Personal profile"),
+    ]
+
     twitter_handle = models.CharField(
         max_length=255,
         blank=True,
@@ -184,6 +191,12 @@ class SocialMediaSettings(BaseSiteSetting):
     )
     linkedin_handle = models.CharField(
         max_length=255, blank=True, help_text="Your Linkedin handle, e.g. katyperry."
+    )
+    linkedin_profile_type = models.CharField(
+        max_length=20,
+        choices=LINKEDIN_PROFILE_CHOICES,
+        default=LINKEDIN_PROFILE_COMPANY,
+        help_text="Choose whether the LinkedIn handle is for a company page or personal profile.",
     )
     facebook_app_id = models.CharField(
         max_length=255, blank=True, help_text="Your Facebook app ID."

--- a/templates/navigation/footer.html
+++ b/templates/navigation/footer.html
@@ -68,7 +68,7 @@
                 <p class="sr-only">Follow us</p>
                 <div class="flex flex-row gap-10 pt-14">
                     {% if settings.utils.SocialMediaSettings.linkedin_handle %}
-                    <a href="https://linkedin.com/company/{{ settings.utils.SocialMediaSettings.linkedin_handle }}"
+                    <a href="https://linkedin.com/{{ settings.utils.SocialMediaSettings.linkedin_profile_type }}/{{ settings.utils.SocialMediaSettings.linkedin_handle }}"
                         aria-label="{{ current_site.site_name|default:'We&apos;re' }} on LinkedIn"
                         class="hover:text-mackerel-300">
                         <svg aria-hidden="true" class="fill-current w-7 h-7" width="30" height="31" viewBox="0 0 30 31" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
Fixes #63

The LinkedIn footer link was hardcoded to `linkedin.com/company/...`, which only works for company pages.
This change adds an admin-selectable LinkedIn profile type so sites can use either:

- `linkedin.com/company/<handle>`
- `linkedin.com/in/<handle>`

## Changes
- Added `linkedin_profile_type` to `SocialMediaSettings` with choices:
  - `company` (default)
  - `in`
- Updated footer LinkedIn URL to use the selected profile type.
- Updated template initial migration (`project_name/utils/migrations/0001_initial.py`) to include the new field.
- Updated demo fixture entry for `utils.socialmediasettings` with `"linkedin_profile_type": "company"`.


<img width="1047" height="427" alt="Screenshot from 2026-02-25 00-41-50" src="https://github.com/user-attachments/assets/0e388872-8a88-44e5-ab85-bb600d3e378c" />

