### PR TITLE
Fix capitalization of 'macOS' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project template is designed for creating [Wagtail](https://wagtail.org) bu
    py --version
    ```
 
-2. **Create a Virtual Environment**: Set up a virtual environment to isolate your project dependencies. These instructions are for GNU/Linux or MacOS, but there are [other operating systems in the Wagtail docs](https://docs.wagtail.org/en/stable/getting_started/tutorial.html#create-and-activate-a-virtual-environment).
+2. **Create a Virtual Environment**: Set up a virtual environment to isolate your project dependencies. These instructions are for GNU/Linux or macOS, but there are [other operating systems in the Wagtail docs](https://docs.wagtail.org/en/stable/getting_started/tutorial.html#create-and-activate-a-virtual-environment).
 
    ```bash
    python -m venv myproject/env


### PR DESCRIPTION
- Apple uses macOS after the release of macOS Sierra in 2016. 
- They have used macOS consistently at their own site : https://support.apple.com/en-ca/109033

## AI Usage
None