### PR TITLE
Fix numbering in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ This project template is designed for creating [Wagtail](https://wagtail.org) bu
 
 All commands from now on should be run from inside the virtual environment.
 
-8. **Load Dummy Data**: Load in some dummy data to populate the site with some content.
+7. **Load Dummy Data**: Load in some dummy data to populate the site with some content.
 
    ```bash
    make load-data
    ```
 
-9. **Start the Server**: Start the Django development server.
+8. **Start the Server**: Start the Django development server.
 
    ```bash
    make start
    ```
 
-10. **Access the Site and Admin**: Once the server is running, you can view the site at `localhost:8000` and access the Wagtail admin interface at `localhost:8000/admin`. Log in with the default credentials provided by :
+9. **Access the Site and Admin**: Once the server is running, you can view the site at `localhost:8000` and access the Wagtail admin interface at `localhost:8000/admin`. Log in with the default credentials provided by :
 
     - Username: admin
     - Password: password


### PR DESCRIPTION
Fix incorrect step numbering in the Getting Started section of the README for consistency and clarity.

## AI Usage 
None