### PR TITLE
Remove unnecessary media/.gitignore

### DIFF
--- a/media/.gitignore
+++ b/media/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
Removes `media/.gitignore` as suggested in issue #8 and relies on the root `.gitignore` instead.

Fixes part of #8

## AI Usage 
None
