### PR TITLE
Pass request when resolving page URL in LinkStructValue

### DIFF
--- a/project_name/utils/struct_values.py
+++ b/project_name/utils/struct_values.py
@@ -8,7 +8,8 @@ class LinkStructValue(blocks.StructValue):
             return link
 
         if page := self.get("page"):
-            return page.url
+            request = self.context.get("request")
+            return page.get_url(request=request)
 
         if document := self.get("document"):
             return document.url


### PR DESCRIPTION
Pass the request object when resolving page URLs instead of using page.url.

Fixes part of #8

## AI Usage
None