### PR TITLE
Fix responsive image fallback in card components

### DIFF
--- a/templates/components/card--article.html
+++ b/templates/components/card--article.html
@@ -35,17 +35,17 @@ w-full h-full group
             <source srcset="{{ card_image_1x_webp.url }} 1x, {{ card_image_2x_webp.url }} 2x" type="image/webp" />
             <source srcset="{{ card_image_1x_jpg.url }} 1x, {{ card_image_2x_jpg.url }} 2x" type="image/jpeg" />
             <img
-                src="{{ card_image_1x_webp.url }}"
-                width="{{ card_image_1x_webp.width }}"
-                height="{{ card_image_1x_webp.height }}"
-                alt="{{ card_image_1x_webp.alt }}"
+                src="{{ card_image_1x_jpg.url }}"
+                width="{{ card_image_1x_jpg.width }}"
+                height="{{ card_image_1x_jpg.height }}"
+                alt="{{ card_image_1x_jpg.alt }}"
 
                 class="
                 aspect-[20/11] 
                 md:aspect-[1]
                 w-full h-full object-cover"
-                {% if card_image_1x_webp.focal_point %}
-                style='{{ card_image_1x_webp.object_position_style }}'
+                {% if card_image_1x_jpg.focal_point %}
+                style='{{ card_image_1x_jpg.object_position_style }}'
                 {% endif %}
             />
         </picture>

--- a/templates/components/card.html
+++ b/templates/components/card.html
@@ -29,18 +29,18 @@ w-full h-full group
             <source srcset="{{ card_image_1x_webp.url }} 1x, {{ card_image_2x_webp.url }} 2x" type="image/webp" />
             <source srcset="{{ card_image_1x_jpg.url }} 1x, {{ card_image_2x_jpg.url }} 2x" type="image/jpeg" />
             <img
-                src="{{ card_image_1x_webp.url }}"
-                width="{{ card_image_1x_webp.width }}"
-                height="{{ card_image_1x_webp.height }}"
-                alt="{{ card_image_1x_webp.alt }}"
+                src="{{ card_image_1x_jpg.url }}"
+                width="{{ card_image_1x_jpg.width }}"
+                height="{{ card_image_1x_jpg.height }}"
+                alt="{{ card_image_1x_jpg.alt }}"
 
                 class="
                 aspect-[20/11] 
                 md:aspect-[4/3] lg:aspect-[20/11] 
                 
                 w-full h-full object-cover"
-                {% if card_image_1x_webp.focal_point %}
-                style='{{ card_image_1x_webp.object_position_style }}'
+                {% if card_image_1x_jpg.focal_point %}
+                style='{{ card_image_1x_jpg.object_position_style }}'
                 {% endif %}
             />
         </picture>


### PR DESCRIPTION
Updates the card components so the `<img>` fallback uses the JPEG rendition instead of WebP.

In a `<picture>` element, the `<img>` tag acts as the final fallback for browsers that do not support the `<source>` formats. Using JPEG here ensures broader compatibility when WebP is not supported.

Related to issue #8.

## AI Usage
None