### PR TITLE
Fix: Add missing reverse import to resolve NameError in search view tests

### DIFF
--- a/project_name/search/tests/test_view.py
+++ b/project_name/search/tests/test_view.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.test import override_settings
+from django.urls import reverse
 from wagtail.models import Site
 from django.test import TestCase
 


### PR DESCRIPTION
**Description**
While setting up the `news-template` locally to explore it for GSoC 2026, I ran the test suite and noticed that the search view tests fail immediately on a fresh scaffold with `NameError: name 'reverse' is not defined`.

This PR adds the missing from `django.urls import reverse import` to `project_name/search/tests/test_view.py` so the test suite can pass out of the box for new developers.

**Testing**
Ran `python manage.py` test locally. The `SearchViewTests` now execute and pass successfully.