### PR TITLE
Fix: Resolve NameError in news pagination and AttributeError for SEO_NOINDEX

### DIFF
--- a/project_name/news/models.py
+++ b/project_name/news/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.db.models.functions import Coalesce
-from django.core.paginator import Paginator
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from wagtail.admin.panels import FieldPanel, HelpPanel, InlinePanel, MultiFieldPanel
 from wagtail.fields import RichTextField
 from wagtail.search import index

--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -260,6 +260,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10_000
 # Wagtail settings
 
 WAGTAIL_SITE_NAME = "{{ project_name }}"
+SEO_NOINDEX = False
 
 # Search
 # https://docs.wagtail.org/en/stable/topics/search/backends.html


### PR DESCRIPTION
Following up on my initial test suite fix, I continued auditing the runtime execution paths of the starter kit and found two bugs that will crash a newly scaffolded project:

**1. Pagination Crash:** In `news/models.py`, `paginate_queryset` catches `PageNotAnInteger` and E`mptyPage`, but neither exception is imported. Navigating to an invalid page number on the news listing raises a `NameError`. Added the missing imports.
**2. Context Processor Crash:** `utils/context_processors.py` reads `settings.SEO_NOINDEX` to inject into the global template context, but `SEO_NOINDEX` is never defined in `base.py`, `dev.py`, or `production.py`. This raises an `AttributeError` on pages utilizing this context. Added a safe default of `False` to `base.py`.

**Testing**
Verified locally that navigating to `?page=999` on the news listing now correctly returns the last page instead of crashing, and the global context processor evaluates safely.