### PR TITLE
Fix form field error messages not rendering

### DIFF
--- a/templates/components/form-field.html
+++ b/templates/components/form-field.html
@@ -12,7 +12,7 @@
                 <ul>
                     {% for error in field.errors %}
                     <li class="text-red-400 font-bold text-sm leading-7">
-                        {{ error {{
+                        {{ error }}
                     </li>
                     {% endfor %}
                 </ul>
@@ -52,7 +52,7 @@
             <ul>
                 {% for error in field.errors %}
                 <li class="text-red-400 font-bold text-sm leading-7">
-                    {{ error {{
+                    {{ error }}
                 </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
### Description
Fix #92 
While setting up the template fresh and testing the contact form, I noticed the error messages weren't showing properly. Submitting the form empty displayed `{{ error {{` as literal text instead of the actual validation message.
Traced it to a typo in `templates/components/form-field.html` the closing `}}` was written as `{{` on two lines (line 15 and 55), 
which broke Django's template rendering for those expressions.

Fixed both occurrences. Error messages now display correctly as "This field is required." in red.

Tested by submitting the contact form empty on a fresh scaffold.

### AI usage

None.

<img width="2508" height="1260" alt="image" src="https://github.com/user-attachments/assets/f356932a-dab6-4228-8ebe-f912a3321984" />
