### PR TITLE
fix(utils): import slugify in models.py

### DIFF
--- a/project_name/utils/models.py
+++ b/project_name/utils/models.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.db.models import QuerySet
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
+from django.utils.text import slugify
 from modelcluster.fields import ParentalKey
 from willow.image import Image as WillowImage
 


### PR DESCRIPTION
## Problem
In `utils/models.py`, the `ArticleTopic` model defines a custom `slugify` method that attempts to call Django's built-in `slugify(title, allow_unicode=True)`. However, because the `slugify` function was never imported, invoking `.save()` on an `ArticleTopic` instance throws a `NameError: name 'slugify' is not defined`.

## Solution  
Added `from django.utils.text import slugify` to the top of `project_name/utils/models.py` to make it available to the class methods.

## Testing
Verified locally by tracing the missing import in the Django module structure. 

Closes #94