### PR TITLE
fix: NameError: Slugify not imported in model.py in utils app

### DIFF
--- a/project_name/utils/models.py
+++ b/project_name/utils/models.py
@@ -7,6 +7,7 @@ from django.db import models
 from django.db.models import QuerySet
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
+from django.utils.text import slugify
 from modelcluster.fields import ParentalKey
 from willow.image import Image as WillowImage
 


### PR DESCRIPTION
Fixes #94

`slugify` was called in `project_name/utils/models.py` but never imported, causing a `NameError` at runtime. The function was used without a corresponding import statement at the top of the file. Adds the missing `from django.utils.text import slugify` import to `utils/models.py`. Verified by confirming the `NameError` no longer occurs when the affected code path is executed.