### PR TITLE
Add test coverage for models, templatetags, and views

### DIFF
--- a/project_name/news/tests/test_models.py
+++ b/project_name/news/tests/test_models.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+
+from wagtail.models import Page, Site
+
+from project_name.home.models import HomePage
+from project_name.news.models import ArticlePage, NewsListingPage
+from project_name.utils.models import AuthorSnippet, ArticleTopic
+
+
+class ArticlePageTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.home = HomePage.objects.first()
+        cls.author = AuthorSnippet.objects.create(title="Test Author")
+        cls.topic = ArticleTopic.objects.create(title="Tech", slug="tech")
+        cls.news_listing = cls.home.add_child(
+            instance=NewsListingPage(title="News", slug="news")
+        )
+        cls.article = cls.news_listing.add_child(
+            instance=ArticlePage(
+                title="Test Article",
+                slug="test-article",
+                author=cls.author,
+                topic=cls.topic,
+                introduction="Test intro",
+            )
+        )
+
+    def test_display_date_uses_publication_date(self):
+        pub_date = timezone.make_aware(datetime(2025, 3, 15, 12, 0))
+        self.article.publication_date = pub_date
+        self.assertEqual(self.article.display_date, "15 Mar 2025")
+
+    def test_display_date_falls_back_to_first_published(self):
+        self.article.publication_date = None
+        self.article.first_published_at = timezone.make_aware(
+            datetime(2025, 1, 10, 12, 0)
+        )
+        self.assertEqual(self.article.display_date, "10 Jan 2025")
+
+    def test_display_date_returns_none_when_no_dates(self):
+        self.article.publication_date = None
+        self.article.first_published_at = None
+        self.assertIsNone(self.article.display_date)
+
+    def test_parent_page_type_is_news_listing(self):
+        self.assertEqual(
+            ArticlePage.parent_page_types, ["news.NewsListingPage"]
+        )
+
+
+class NewsListingPageTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.home = HomePage.objects.first()
+        cls.news_listing = cls.home.add_child(
+            instance=NewsListingPage(title="News", slug="news")
+        )
+
+        site = Site.objects.get(is_default_site=True)
+        site.hostname = "testserver"
+        site.save()
+
+    def test_max_count_is_one(self):
+        self.assertEqual(NewsListingPage.max_count, 1)
+
+    def test_subpage_type_is_article(self):
+        self.assertEqual(
+            NewsListingPage.subpage_types, ["news.ArticlePage"]
+        )
+
+    def test_news_listing_page_loads(self):
+        response = self.client.get(self.news_listing.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_context_contains_pagination_keys(self):
+        response = self.client.get(self.news_listing.url)
+        self.assertIn("paginator", response.context)
+        self.assertIn("paginator_page", response.context)
+        self.assertIn("is_paginated", response.context)
+        self.assertIn("topics", response.context)

--- a/project_name/utils/tests/test_models.py
+++ b/project_name/utils/tests/test_models.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+
+from project_name.utils.models import AuthorSnippet, ArticleTopic, Statistic
+
+
+class AuthorSnippetTests(TestCase):
+    def test_str_returns_title(self):
+        author = AuthorSnippet(title="Jane Doe")
+        self.assertEqual(str(author), "Jane Doe")
+
+
+class ArticleTopicTests(TestCase):
+    def test_str_returns_title(self):
+        topic = ArticleTopic(title="Technology", slug="technology")
+        self.assertEqual(str(topic), "Technology")
+
+    def test_slugify_generates_slug(self):
+        topic = ArticleTopic(title="Hello World")
+        slug = topic.slugify("Hello World")
+        self.assertEqual(slug, "hello-world")
+
+    def test_slugify_with_counter(self):
+        topic = ArticleTopic(title="Hello World")
+        slug = topic.slugify("Hello World", 2)
+        self.assertEqual(slug, "hello-world_2")
+
+
+class StatisticTests(TestCase):
+    def test_str_returns_statistic(self):
+        stat = Statistic(statistic="100+", description="Happy users")
+        self.assertEqual(str(stat), "100+")

--- a/project_name/utils/tests/test_templatetags.py
+++ b/project_name/utils/tests/test_templatetags.py
@@ -1,0 +1,72 @@
+from django.http import QueryDict
+from django.test import TestCase, RequestFactory
+
+from project_name.utils.templatetags.util_tags import (
+    format_heading_id,
+    get_base_querydict,
+    clean_querydict,
+)
+
+
+class FormatHeadingIdTests(TestCase):
+    def test_generates_slugified_id(self):
+        result = format_heading_id("Hello World", "abcdef1234567890")
+        self.assertEqual(result, "hello-world-abcdef12")
+
+    def test_truncates_id_to_8_chars(self):
+        result = format_heading_id("Test", "1234567890abcdef")
+        self.assertEqual(result, "test-12345678")
+
+    def test_handles_special_characters(self):
+        result = format_heading_id("Hello & World!", "abcdef12")
+        self.assertEqual(result, "hello-world-abcdef12")
+
+
+class GetBaseQuerydictTests(TestCase):
+    def test_returns_empty_querydict_when_no_request_or_base(self):
+        result = get_base_querydict({}, None)
+        self.assertIsInstance(result, QueryDict)
+        self.assertEqual(len(result), 0)
+
+    def test_copies_request_get_when_base_is_none(self):
+        factory = RequestFactory()
+        request = factory.get("/?foo=bar")
+        context = {"request": request}
+        result = get_base_querydict(context, None)
+        self.assertEqual(result["foo"], "bar")
+
+    def test_copies_querydict_base(self):
+        base = QueryDict("a=1&b=2")
+        result = get_base_querydict({}, base)
+        self.assertEqual(result["a"], "1")
+        self.assertEqual(result["b"], "2")
+
+    def test_string_base(self):
+        result = get_base_querydict({}, "x=10&y=20")
+        self.assertEqual(result["x"], "10")
+        self.assertEqual(result["y"], "20")
+
+
+class CleanQuerydictTests(TestCase):
+    def test_removes_none_values(self):
+        qd = QueryDict(mutable=True)
+        qd.setlist("key", ["value", None])
+        clean_querydict(qd)
+        self.assertEqual(qd.getlist("key"), ["value"])
+
+    def test_removes_blank_values_when_flag_set(self):
+        qd = QueryDict(mutable=True)
+        qd.setlist("key", ["value", ""])
+        clean_querydict(qd, remove_blanks=True)
+        self.assertEqual(qd.getlist("key"), ["value"])
+
+    def test_removes_utm_params(self):
+        qd = QueryDict("utm_source=google&foo=bar", mutable=True)
+        clean_querydict(qd, remove_utm=True)
+        self.assertNotIn("utm_source", qd)
+        self.assertEqual(qd["foo"], "bar")
+
+    def test_keeps_utm_params_when_flag_false(self):
+        qd = QueryDict("utm_source=google&foo=bar", mutable=True)
+        clean_querydict(qd, remove_utm=False)
+        self.assertIn("utm_source", qd)


### PR DESCRIPTION
Fixes #104 

## Description

The project has only 1 test file with 3 tests and zero coverage for models, 
templatetags, and news app logic. This PR adds comprehensive test coverage:

- **utils/tests/test_models.py**: Tests for `AuthorSnippet.__str__`, 
  `ArticleTopic.__str__` and `slugify()` method, `Statistic.__str__`
- **utils/tests/test_templatetags.py**: Tests for `format_heading_id`, 
  `get_base_querydict` (request context, QueryDict, string bases), 
  `clean_querydict` (None removal, blank removal, UTM param stripping)
- **news/tests/test_models.py**: Tests for `ArticlePage.display_date` 
  (publication date, first_published_at fallback, no dates), 
  `NewsListingPage` constraints and pagination context

## AI Usage

Claude (claude-sonnet-4-6) was used to help identify untested areas 
and assist with writing the test cases. All tests were written and 
submitted by me.

