### PR TITLE
Fix newsletter signup by wrapping input in form element

### DIFF
--- a/templates/navigation/footer.html
+++ b/templates/navigation/footer.html
@@ -53,14 +53,16 @@
                         {{ settings.utils.SystemMessagesSettings.footer_newsletter_signup_description }}
                     </p>
                     {% endif %}
-                    <div class="pt-5 flex gap-1 md:gap-2.5">
-                        <input 
-                            type="email" 
-                            placeholder="Enter your email" 
+                    <form class="pt-5 flex gap-1 md:gap-2.5" action="{{ settings.utils.SystemMessagesSettings.footer_newsletter_signup_link }}" method="get">
+                        <input
+                            type="email"
+                            name="email"
+                            required
+                            placeholder="Enter your email"
                             aria-labelledby="footer-newsletter-signup-title"
                             class="border-[1px] border-mackerel-200 rounded-[3px] px-5 md:py-2.5 md:px-5 text-base md:text-lg bg-white dark:bg-mackerel-100 dark:text-white">
-                        {% include "components/button.html" with variant="footer" title="Sign up" url=settings.utils.SystemMessagesSettings.footer_newsletter_signup_link %}
-                    </div>
+                        {% include "components/button.html" with variant="footer" title="Sign up" %}
+                    </form>
                 </div>
             {% endif %}
 


### PR DESCRIPTION
Fixes #106 

### Description

The newsletter signup in the footer was non-functional. The email `<input>` had no connection to the "Sign up" button — the button rendered as an `<a>` tag linking to an external URL, silently ignoring whatever the user typed.

**Changes made in `templates/navigation/footer.html`:**
- Wrapped the input and button in a `<form>` with `action` set to the configured signup URL and `method="get"`
- Added `name="email"` and `required` to the input so the value is included in form submission
- Removed `url` from the button include so it renders as a `<button type="submit">` instead of an anchor tag

The email entered by the user is now passed to the external newsletter service as a query parameter (e.g. `?email=user@example.com`), which most services support for pre-filling the signup form.

### AI usage

None
