### PR TITLE
Remove duplicate import in home/models.py

### DIFF
--- a/project_name/home/models.py
+++ b/project_name/home/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.db import models
 from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.search import index
 


### PR DESCRIPTION
This removes a duplicate import of `models` in `home/models.py`.

No functional changes — just a small cleanup for code clarity.

## AI Usage
None

