### PR TITLE
Fix incorrect AppConfig class name for forms app

### DIFF
--- a/project_name/forms/apps.py
+++ b/project_name/forms/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
 
-class NewsConfig(AppConfig):
+class FormsConfig(AppConfig):
     default_auto_field: str = "django.db.models.AutoField"
     name = "{{ project_name }}.forms"


### PR DESCRIPTION
Renames `NewsConfig` to `FormsConfig` in `forms/apps.py` to match the app name.

## AI Usage
None