### PR TITLE
Add template for ArticlePageLinkBlock with safe fallback rendering

### DIFF
--- a/templates/components/streamfield/blocks/article_page_link_block.html
+++ b/templates/components/streamfield/blocks/article_page_link_block.html
@@ -1,0 +1,10 @@
+{% load wagtailcore_tags %}
+
+{% if value.page %}
+    <a href="{% pageurl value.page %}" 
+    class="block-link block-link--internal"
+    title="{{ value.title|default:value.page.title }}">
+        {{ value.title|default:value.page.title }}
+    
+    </a>
+{% endif %}


### PR DESCRIPTION
Fixes #38

### Description

This PR adds a basic frontend template for ArticlePageLinkBlock to address missing rendering support.

### Implementation

* Uses `{% pageurl %}` for correct internal routing
* Displays `value.title` with a fallback to `page.title`
* Ensures safe rendering when optional fields are not provided
* Keeps implementation minimal and consistent with existing starter kit templates

### Testing

* Tested via FeaturedArticleBlock where ArticlePageLinkBlock is used internally
* Verified correct rendering on the frontend
* Confirmed fallback behavior when title is not provided

Frontend (rendered output): 
<img width="1889" height="968" alt="Screenshot 2026-04-02 005011" src="https://github.com/user-attachments/assets/ace585bf-f808-4a00-a588-2b21561c2f9d" />
Admin (block configuration):
<img width="1905" height="970" alt="Screenshot 2026-04-02 005000" src="https://github.com/user-attachments/assets/08958cec-df4e-4d92-831f-95ea4f905266" />

Happy to adjust based on feedback!

### AI usage

AI assistance was used for minor guidance and review.


