### PR TITLE
Fix/accordion block duplicate class

### DIFF
--- a/project_name/utils/blocks.py
+++ b/project_name/utils/blocks.py
@@ -11,7 +11,7 @@ from wagtail.snippets.blocks import SnippetChooserBlock
 from {{ project_name }}.utils.struct_values import CardStructValue, LinkStructValue
 
 
-class AccordionBlock(blocks.StructBlock):
+class AccordionPanelBlock(blocks.StructBlock):
     title = blocks.CharBlock(max_length=255)
     content = blocks.RichTextBlock()
 
@@ -21,8 +21,8 @@ class AccordionBlock(blocks.StructBlock):
 
 
 class AccordionBlock(blocks.StructBlock):
-    heading = blocks.ListBlock(AccordionBlock())
-    list = blocks.ListBlock(AccordionBlock())
+    heading = blocks.CharBlock(max_length=255, required=False)
+    panels = blocks.ListBlock(AccordionPanelBlock())
 
     class Meta:
         icon = "list-ol"


### PR DESCRIPTION
Fixes #116 

### Description

`AccordionBlock` was defined twice consecutively in `project_name/utils/blocks.py`, causing the second class definition to silently overwrite the first in Python's namespace.

This resulted in the parent `AccordionBlock` incorrectly referencing itself via `ListBlock(AccordionBlock())` for both its `heading` and `list` fields — instead of referencing the intended inner panel-level block.

**Changes made:**
- Renamed the first (item-level) `AccordionBlock` to `AccordionPanelBlock`
- Updated `AccordionBlock.heading` to a `CharBlock(max_length=255, required=False)`
- Updated `AccordionBlock.panels` to use `ListBlock(AccordionPanelBlock())`
- Renamed the `list` field to `panels` to avoid shadowing the Python built-in `list`

### AI usage

None
