### PR TITLE
Add template for LinkStreamBlock and register it in Meta for proper r…

### DIFF
--- a/project_name/utils/blocks.py
+++ b/project_name/utils/blocks.py
@@ -78,6 +78,7 @@ class LinkStreamBlock(blocks.StreamBlock):
     external = ExternalLinkBlock()
 
     class Meta:
+        template="components/streamfield/blocks/link_stream_block.html"
         icon = "link"
         label = "Link"
         min_num = 1

--- a/templates/components/streamfield/blocks/link_stream_block.html
+++ b/templates/components/streamfield/blocks/link_stream_block.html
@@ -1,0 +1,9 @@
+{% load wagtailcore_tags %}
+
+{% if value %}
+    {% for block in value %}
+        <div class="link-stream link-stream--{{ block.block_type }}">
+            {% include_block block %}
+        </div>
+    {% endfor %}
+{% endif %}


### PR DESCRIPTION
Fixes #38

Description

Adds a basic frontend template for LinkStreamBlock to enable proper rendering in StreamField.

The block allows selecting a single link (internal or external). This PR introduces a simple template that safely iterates over the block value and renders the selected link using {% include_block %}, ensuring compatibility with existing child blocks.

Also registers the template in LinkStreamBlock.Meta so it is picked up automatically.

AI usage

None 