### PR TITLE
Fix missing transaction and router imports in ArticleTopic.save()

### DIFF
--- a/project_name/utils/models.py
+++ b/project_name/utils/models.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.core.files.images import ImageFile
 from django.contrib.staticfiles.finders import find
-from django.db import models
+from django.db import models, transaction, router
 from django.db.models import QuerySet
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property


### PR DESCRIPTION

Fixes #124

### Description

ArticleTopic.save() uses transaction.atomic() and router.db_for_write()
but neither is imported, causing a NameError at runtime when saving a new
topic with a duplicate title.

Added the imports to resolve this issue 

<img width="497" height="77" alt="image" src="https://github.com/user-attachments/assets/54350d8d-26b2-4dca-801b-8e80061d6ddc" />


### AI usage

None

