### PR TITLE
fix: add missing imports for transaction and router in ArticleTopic.save() (closes #124)

### DIFF
--- a/project_name/utils/models.py
+++ b/project_name/utils/models.py
@@ -3,8 +3,9 @@ from bs4 import BeautifulSoup
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.core.files.images import ImageFile
 from django.contrib.staticfiles.finders import find
-from django.db import models
+from django.db import models, transaction
 from django.db.models import QuerySet
+from django.db.utils import router
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from modelcluster.fields import ParentalKey


### PR DESCRIPTION
## What
`ArticleTopic.save()` uses `transaction.atomic()` and `router.db_for_write()` but neither `transaction` (from django.db) nor `router` (from django.db.utils) were imported. This causes a `NameError` at runtime when saving a new topic that triggers the duplicate title handling logic.

## Fix
Added the missing imports:
- `from django.db import transaction`
- `from django.db.utils import router`

Closes #124