### PR TITLE
Fix template smoke test recursion in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,36 +44,35 @@ jobs:
 
       - name: Generate project from template
         run: |
-          mkdir smoketest
-          cd smoketest
+          cd /tmp
           wagtail start --template="$GITHUB_WORKSPACE" testproject
 
       - name: Install generated project dependencies
         run: |
-          cd smoketest/testproject
+          cd /tmp/testproject
           pip install -r requirements.txt
 
       - name: Django check
         run: |
-          cd smoketest/testproject
+          cd /tmp/testproject
           python manage.py check
 
       - name: Run migrations
         run: |
-          cd smoketest/testproject
+          cd /tmp/testproject
           python manage.py migrate
 
       - name: Create cache table
         run: |
-          cd smoketest/testproject
+          cd /tmp/testproject
           python manage.py createcachetable
 
       - name: Load initial data
         run: |
-          cd smoketest/testproject
+          cd /tmp/testproject
           python manage.py load_initial_data
 
       - name: Collect static files
         run: |
-          cd smoketest/testproject
+          cd /tmp/testproject
           python manage.py collectstatic --noinput


### PR DESCRIPTION
This PR fixes the template smoke test workflow introduced in #128.

The original workflow generated the test project inside the repository workspace:

news-template/
└── smoketest/
    └── testproject/

During GitHub Actions execution, Wagtail recursively discovered the generated project while processing the template, resulting in paths such as:

smoketest/testproject/smoketest/testproject/...

until Linux eventually raised:

OSError: [Errno 36] File name too long
Changes
Generate the smoke test project in /tmp instead of inside the repository workspace.
Update all subsequent smoke test steps to operate on /tmp/testproject.
Result

The generated project is now completely outside the template directory, preventing recursive template generation while preserving the existing smoke test workflow.

### AI usage

Yes , AI has been used to detect the issues and write description.
