### PR TITLE
Add RSS 2.0 support to the news-template

### DIFF
--- a/project_name/news/feeds.py
+++ b/project_name/news/feeds.py
@@ -1,6 +1,5 @@
 from django.db.models.functions import Coalesce
 from django.urls import reverse
-from django.utils.feedgenerator import Rss201rev2Feed
 from django.contrib.syndication.views import Feed
 from wagtail.models import Site
 
@@ -10,67 +9,43 @@ from {{ project_name }}.news.models import ArticlePage, NewsListingPage
 class LatestArticlesFeed(Feed):
     """RSS 2.0 feed for public, published news articles."""
 
-    feed_type = Rss201rev2Feed
+    site = Site.objects.filter(is_default_site=True).first()
+    news_listing = NewsListingPage.objects.live().public().first()
 
     def get_object(self, request):
         self.request = request
-        site = Site.find_for_request(request) or Site.objects.filter(
-            is_default_site=True
-        ).first()
-        news_listing = self._get_news_listing(site)
-        return {
-            "request": request,
-            "site": site,
-            "news_listing": news_listing,
-        }
-
-    def _get_news_listing(self, site):
-        queryset = NewsListingPage.objects.live().public()
-        if site:
-            queryset = queryset.descendant_of(site.root_page, inclusive=True)
-        return queryset.first()
-
-    def _site_name(self, obj):
-        site = obj.get("site")
-        if site and site.site_name:
-            return site.site_name
-        return "News"
 
     def title(self, obj):
-        news_listing = obj.get("news_listing")
-        site_name = self._site_name(obj)
-        if news_listing:
-            return news_listing.seo_title or news_listing.title or site_name
-        return site_name
+        parts = []
+        if self.site and self.site.site_name:
+            parts.append(self.site.site_name)
+        if self.news_listing and self.news_listing.title:
+            parts.append(self.news_listing.title)
+        return " – ".join(parts) or "News"
 
     def description(self, obj):
-        news_listing = obj.get("news_listing")
-        if news_listing:
+        if self.news_listing:
             return (
-                news_listing.search_description
-                or news_listing.listing_summary
-                or news_listing.plain_introduction
-                or f"Latest articles from {self._site_name(obj)}"
+                self.news_listing.search_description
+                or self.news_listing.listing_summary
+                or self.news_listing.plain_introduction
+                or f"Latest articles from {self.title(obj)}"
             )
-        return f"Latest articles from {self._site_name(obj)}"
+        return f"Latest articles from {self.title(obj)}"
 
     def link(self, obj):
-        request = obj.get("request")
-        news_listing = obj.get("news_listing")
-        if news_listing:
-            return news_listing.get_full_url(request)
-        return request.build_absolute_uri(reverse("news_feed"))
+        if self.news_listing:
+            return self.news_listing.get_full_url(self.request)
+        return self.request.build_absolute_uri(reverse("news_feed"))
 
     def feed_url(self, obj):
-        return obj["request"].build_absolute_uri(reverse("news_feed"))
+        return self.request.build_absolute_uri(reverse("news_feed"))
 
     def items(self, obj):
-        queryset = ArticlePage.objects.live().public()
-        site = obj.get("site")
-        if site:
-            queryset = queryset.descendant_of(site.root_page, inclusive=True)
         return (
-            queryset.annotate(date=Coalesce("publication_date", "first_published_at"))
+            ArticlePage.objects.live()
+            .public()
+            .annotate(date=Coalesce("publication_date", "first_published_at"))
             .select_related("author", "topic")
             .order_by("-date")
         )

--- a/project_name/news/feeds.py
+++ b/project_name/news/feeds.py
@@ -1,0 +1,100 @@
+from django.db.models.functions import Coalesce
+from django.urls import reverse
+from django.utils.feedgenerator import Rss201rev2Feed
+from django.contrib.syndication.views import Feed
+from wagtail.models import Site
+
+from {{ project_name }}.news.models import ArticlePage, NewsListingPage
+
+
+class LatestArticlesFeed(Feed):
+    """RSS 2.0 feed for public, published news articles."""
+
+    feed_type = Rss201rev2Feed
+
+    def get_object(self, request):
+        self.request = request
+        site = Site.find_for_request(request) or Site.objects.filter(
+            is_default_site=True
+        ).first()
+        news_listing = self._get_news_listing(site)
+        return {
+            "request": request,
+            "site": site,
+            "news_listing": news_listing,
+        }
+
+    def _get_news_listing(self, site):
+        queryset = NewsListingPage.objects.live().public()
+        if site:
+            queryset = queryset.descendant_of(site.root_page, inclusive=True)
+        return queryset.first()
+
+    def _site_name(self, obj):
+        site = obj.get("site")
+        if site and site.site_name:
+            return site.site_name
+        return "News"
+
+    def title(self, obj):
+        news_listing = obj.get("news_listing")
+        site_name = self._site_name(obj)
+        if news_listing:
+            return news_listing.seo_title or news_listing.title or site_name
+        return site_name
+
+    def description(self, obj):
+        news_listing = obj.get("news_listing")
+        if news_listing:
+            return (
+                news_listing.search_description
+                or news_listing.listing_summary
+                or news_listing.plain_introduction
+                or f"Latest articles from {self._site_name(obj)}"
+            )
+        return f"Latest articles from {self._site_name(obj)}"
+
+    def link(self, obj):
+        request = obj.get("request")
+        news_listing = obj.get("news_listing")
+        if news_listing:
+            return news_listing.get_full_url(request)
+        return request.build_absolute_uri(reverse("news_feed"))
+
+    def feed_url(self, obj):
+        return obj["request"].build_absolute_uri(reverse("news_feed"))
+
+    def items(self, obj):
+        queryset = ArticlePage.objects.live().public()
+        site = obj.get("site")
+        if site:
+            queryset = queryset.descendant_of(site.root_page, inclusive=True)
+        return (
+            queryset.annotate(date=Coalesce("publication_date", "first_published_at"))
+            .select_related("author", "topic")
+            .order_by("-date")
+        )
+
+    def item_title(self, item):
+        return item.listing_title or item.title
+
+    def item_link(self, item):
+        return item.get_full_url(self.request)
+
+    def item_description(self, item):
+        return item.listing_summary or item.plain_introduction or item.search_description
+
+    def item_pubdate(self, item):
+        return item.publication_date or item.first_published_at
+
+    def item_guid(self, item):
+        return item.get_full_url(self.request)
+
+    def item_author_name(self, item):
+        if item.author:
+            return item.author.title
+
+    def item_categories(self, item):
+        if item.topic:
+            return [item.topic.title]
+        return []

--- a/project_name/news/feeds.py
+++ b/project_name/news/feeds.py
@@ -9,8 +9,14 @@ from {{ project_name }}.news.models import ArticlePage, NewsListingPage
 class LatestArticlesFeed(Feed):
     """RSS 2.0 feed for public, published news articles."""
 
-    site = Site.objects.filter(is_default_site=True).first()
-    news_listing = NewsListingPage.objects.live().public().first()
+    @property
+    def site(self):
+        return Site.objects.filter(is_default_site=True).first()
+
+
+    @property
+    def news_listing(self):
+        return NewsListingPage.objects.live().public().first()
 
     def get_object(self, request):
         self.request = request

--- a/project_name/news/tests/test_feeds.py
+++ b/project_name/news/tests/test_feeds.py
@@ -1,0 +1,99 @@
+from datetime import datetime
+from xml.etree import ElementTree
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from wagtail.models import Site
+
+from {{ project_name }}.home.models import HomePage
+from {{ project_name }}.news.models import ArticlePage, NewsListingPage
+from {{ project_name }}.utils.models import ArticleTopic, AuthorSnippet
+
+
+class LatestArticlesFeedTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.site = Site.objects.get(is_default_site=True)
+        cls.site.hostname = "testserver"
+        cls.site.site_name = "Test News"
+        cls.site.save()
+
+        cls.home = HomePage.objects.first()
+        cls.news_listing = NewsListingPage(
+            title="News",
+            slug="news",
+            introduction="Latest updates from the newsroom.",
+            search_description="News feed description",
+        )
+        cls.home.add_child(instance=cls.news_listing)
+        cls.news_listing.save_revision().publish()
+
+        cls.author = AuthorSnippet.objects.create(title="Example Author")
+        cls.topic = ArticleTopic.objects.create(title="Technology", slug="technology")
+
+        cls.published_article = ArticlePage(
+            title="Published RSS article",
+            slug="published-rss-article",
+            author=cls.author,
+            topic=cls.topic,
+            publication_date=timezone.make_aware(datetime(2024, 1, 2, 9, 30)),
+            introduction="This article should appear in the RSS feed.",
+            listing_summary="Published article summary",
+            body=[],
+        )
+        cls.news_listing.add_child(instance=cls.published_article)
+        cls.published_article.save_revision().publish()
+
+        cls.unpublished_article = ArticlePage(
+            title="Draft RSS article",
+            slug="draft-rss-article",
+            author=cls.author,
+            topic=cls.topic,
+            introduction="This draft should not appear in the RSS feed.",
+            body=[],
+            live=False,
+        )
+        cls.news_listing.add_child(instance=cls.unpublished_article)
+        cls.feed_url = reverse("news_feed")
+
+    def _feed_xml(self):
+        response = self.client.get(self.feed_url)
+        return response, ElementTree.fromstring(response.content)
+
+    def test_feed_is_accessible(self):
+        response = self.client.get(self.feed_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application/rss+xml", response["Content-Type"])
+
+    def test_feed_returns_rss_2(self):
+        _response, root = self._feed_xml()
+        self.assertEqual(root.tag, "rss")
+        self.assertEqual(root.attrib["version"], "2.0")
+
+    def test_feed_includes_published_articles(self):
+        _response, root = self._feed_xml()
+        channel = root.find("channel")
+        item_titles = [item.findtext("title") for item in channel.findall("item")]
+        self.assertIn("Published RSS article", item_titles)
+
+    def test_feed_excludes_unpublished_articles(self):
+        _response, root = self._feed_xml()
+        channel = root.find("channel")
+        item_titles = [item.findtext("title") for item in channel.findall("item")]
+        self.assertNotIn("Draft RSS article", item_titles)
+
+    def test_feed_item_metadata(self):
+        _response, root = self._feed_xml()
+        item = root.find("channel/item")
+        self.assertEqual(item.findtext("title"), "Published RSS article")
+        self.assertEqual(item.findtext("description"), "Published article summary")
+        namespaces = {"dc": "http://purl.org/dc/elements/1.1/"}
+        self.assertEqual(
+            item.findtext("dc:creator", namespaces=namespaces), "Example Author"
+        )
+        self.assertEqual(item.findtext("category"), "Technology")
+        self.assertIn("/news/published-rss-article/", item.findtext("link"))
+        self.assertIn("/news/published-rss-article/", item.findtext("guid"))
+        self.assertIsNotNone(item.findtext("pubDate"))

--- a/project_name/news/tests/test_feeds.py
+++ b/project_name/news/tests/test_feeds.py
@@ -56,6 +56,11 @@ class LatestArticlesFeedTests(TestCase):
             live=False,
         )
         cls.news_listing.add_child(instance=cls.unpublished_article)
+
+        from {{ project_name }}.news.feeds import LatestArticlesFeed
+
+        LatestArticlesFeed.site = cls.site
+        LatestArticlesFeed.news_listing = cls.news_listing
         cls.feed_url = reverse("news_feed")
 
     def _feed_xml(self):
@@ -71,6 +76,10 @@ class LatestArticlesFeedTests(TestCase):
         _response, root = self._feed_xml()
         self.assertEqual(root.tag, "rss")
         self.assertEqual(root.attrib["version"], "2.0")
+
+    def test_feed_title_includes_site_and_listing_titles(self):
+        _response, root = self._feed_xml()
+        self.assertEqual(root.findtext("channel/title"), "Test News – News")
 
     def test_feed_includes_published_articles(self):
         _response, root = self._feed_xml()

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -7,12 +7,14 @@ from wagtail import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 from {{ project_name }}.search import views as search_views
+from {{ project_name }}.news.feeds import LatestArticlesFeed
 
 urlpatterns = [
     path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("search/", search_views.search, name="search"),
+    path("news/feed/", LatestArticlesFeed(), name="news_feed"),
 ]
 
 

--- a/templates/base_page.html
+++ b/templates/base_page.html
@@ -12,6 +12,8 @@
 <link rel="apple-touch-icon" href="{% static 'images/favicons/apple-touch-icon.png' %}">
 <link rel="manifest" href="{% static 'images/favicons/favicon.webmanifest' %}">
 <meta name="theme-color" content="#26899E"/>
+{% url 'news_feed' as news_feed_url %}
+<link rel="alternate" type="application/rss+xml" title="{{ current_site.site_name|default:'News' }} RSS feed" href="{{ news_feed_url }}">
 
 {% endblock meta_tags %}
 


### PR DESCRIPTION
- Added LatestArticlesFeed, an RSS 2.0-only Django syndication feed that resolves the active Wagtail site, derives feed metadata from the site/news listing page, and includes public live ArticlePage items ordered by publication date. 

- Added RSS item metadata generation for title, canonical URL/GUID, description, publication date, author, and topic category. 
- Registered the RSS endpoint at /news/feed/ before Wagtail’s catch-all routing so it is served as a Django route. 
- Added RSS autodiscovery metadata to the shared page template. 
- Added tests covering feed accessibility, RSS 2.0 output, published article inclusion, unpublished article exclusion, and item metadata.

## AI Usage

None