### PR TITLE
Fix #137: Remove Django admin to prevent user confusion

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -55,7 +55,6 @@ INSTALLED_APPS = [
     "wagtail",
     "modelcluster",
     "taggit",
-    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.urls import include, path
-from django.contrib import admin
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail import urls as wagtail_urls
@@ -10,7 +9,6 @@ from {{ project_name }}.search import views as search_views
 from {{ project_name }}.news.feeds import LatestArticlesFeed
 
 urlpatterns = [
-    path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("search/", search_views.search, name="search"),

--- a/project_name/users/admin.py
+++ b/project_name/users/admin.py
@@ -1,6 +1,0 @@
-from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin
-
-from .models import User
-
-admin.site.register(User, UserAdmin)


### PR DESCRIPTION
This PR resolves issue #137 where users were mistakenly logging into the default Django admin panel and finding it empty, causing confusion over Wagtail's configuration.

Since Wagtail provides its own fully-featured admin panel at `/admin/` (which handles pages, content, and users), the standard Django admin at `/django-admin/` is redundant for this starter kit.

**Changes:**
- Removed `django.contrib.admin` from `INSTALLED_APPS` in `base.py`
- Removed `path("django-admin/", admin.site.urls)` from `urls.py`
- Removed `users/admin.py` to prevent import errors related to `admin.site.register`
